### PR TITLE
Adds cakebox to software environments

### DIFF
--- a/README.md
+++ b/README.md
@@ -355,6 +355,7 @@ Focus is on the specific task.
 ## Development Environment
 *Software and tools for creating a sandboxed development environment.*
 
+- [Cakebox](https://github.com/alt3/cakebox) - A Vagrant development environment powered by the CakePHP 3.x Console.
 - [PuPHPet](https://puphpet.com/) - Web interface for building a Vagrant + Puppet box.
 - [Puppet](http://puppetlabs.com/) - A server automation framework and application.
 - [Vagrant](http://www.vagrantup.com/) - A portable development environment utility.


### PR DESCRIPTION
I would appreciate if you would add my cakebox project to the list. I think it's awesome and some (Laravel) users says it kills their Homestead box (and are now using it instead).

If more information is needed there is:

- extensive [documentation here](http://cakebox.readthedocs.org/en/latest/)
- a picture explaining the [architecture](http://cakebox.readthedocs.org/en/latest/quickstart/#box-architecture).

ps: this box does not use chef-provisioning so... no long waiting times, just vagrant up and wait for the Cake3.x console to self-install. After that.. login to the dashboard or start deploying Cake (2.x/3.x) applications, databases, virtual hosts, etc from the commandline using the Cake 3.x Console shells. Supports both public and private repositories too.

TIA