### PR TITLE
Remove pgbi/softdelete

### DIFF
--- a/README.md
+++ b/README.md
@@ -214,7 +214,6 @@ Focus is on the specific task.
 
 - [Money plugin](https://github.com/gourmet/money) - Money data type for CakePHP entities using [sebastianbergmann/money](https://github.com/sebastianbergmann/money).
 - [Muffin/Trash plugin](https://github.com/usemuffin/trash) - Soft-delete behavior for CakePHP.
-- [SoftDelete plugin](https://github.com/PGBI/cakephp3-soft-delete) - Soft delete for CakePHP models.
 - [PersistRelatedData plugin](https://github.com/riesenia/persist-related-data) - Behavior for persisting selected fields of related models.
 - ~~[Datasources plugin](https://github.com/cakephp/datasources) - Lots of different datasources.~~
 


### PR DESCRIPTION
It overrides the core's query using a trait for something that should be done differently, @see https://github.com/cakephp/cakephp/issues/6407#issuecomment-95846918

For more info on why it was decided to start cleaning up, see #