### PR TITLE
Add OrgasmicNightmare/cakephp-seo plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -275,7 +275,7 @@ Additional lists you might find useful:
 *Search Engine Optimization.*
 
 - [Muffin/Slug plugin](https://github.com/UseMuffin/Slug) - A plugin for generating slugs and finding records by slug. Uses a pluggable architecture which allows using your own slug generator class.
-- [OrgasmicNightmare/cakephp-seo](https://github.com/orgasmicnightmare/cakephp-seo) - Manage seo tags with ease. It comes with a Behavior, a Component, a View Cell and the default admin crud actions for each tables.
+- [Seo plugin](https://github.com/orgasmicnightmare/cakephp-seo) - Manage seo tags with ease. It comes with a Behavior, a Component, a View Cell and the default admin crud actions for each tables.
 - [Sluggable plugin](https://github.com/Xety/Cake3-Sluggable) - A simple Cake3 plugin to slug fields and find records by slug.
 - [Tools:Slugged](https://github.com/dereuromark/cakephp-tools) - Containing Slugged behavior to auto-generate URL-compatible slugs from titles.
 

--- a/README.md
+++ b/README.md
@@ -275,6 +275,7 @@ Additional lists you might find useful:
 *Search Engine Optimization.*
 
 - [Muffin/Slug plugin](https://github.com/UseMuffin/Slug) - A plugin for generating slugs and finding records by slug. Uses a pluggable architecture which allows using your own slug generator class.
+- [OrgasmicNightmare/cakephp-seo](https://github.com/orgasmicnightmare/cakephp-seo) - Manage seo tags with ease. It comes with a Behavior, a Component, a View Cell and the default admin crud actions for each tables.
 - [Sluggable plugin](https://github.com/Xety/Cake3-Sluggable) - A simple Cake3 plugin to slug fields and find records by slug.
 - [Tools:Slugged](https://github.com/dereuromark/cakephp-tools) - Containing Slugged behavior to auto-generate URL-compatible slugs from titles.
 

--- a/README.md
+++ b/README.md
@@ -275,7 +275,7 @@ Additional lists you might find useful:
 *Search Engine Optimization.*
 
 - [Muffin/Slug plugin](https://github.com/UseMuffin/Slug) - A plugin for generating slugs and finding records by slug. Uses a pluggable architecture which allows using your own slug generator class.
-- [Seo plugin](https://github.com/orgasmicnightmare/cakephp-seo) - A plugin to generate and manage your seo tags.
+- [Seo plugin](https://github.com/orgasmicnightmare/cakephp-seo) - Auto-creates and manages your SEO tags.
 - [Sluggable plugin](https://github.com/Xety/Cake3-Sluggable) - A simple Cake3 plugin to slug fields and find records by slug.
 - [Tools:Slugged](https://github.com/dereuromark/cakephp-tools) - Containing Slugged behavior to auto-generate URL-compatible slugs from titles.
 

--- a/README.md
+++ b/README.md
@@ -275,7 +275,7 @@ Additional lists you might find useful:
 *Search Engine Optimization.*
 
 - [Muffin/Slug plugin](https://github.com/UseMuffin/Slug) - A plugin for generating slugs and finding records by slug. Uses a pluggable architecture which allows using your own slug generator class.
-- [Seo plugin](https://github.com/orgasmicnightmare/cakephp-seo) - Manage seo tags with ease. It comes with a Behavior, a Component, a View Cell and the default admin crud actions for each tables.
+- [Seo plugin](https://github.com/orgasmicnightmare/cakephp-seo) - A plugin to generate and manage your seo tags.
 - [Sluggable plugin](https://github.com/Xety/Cake3-Sluggable) - A simple Cake3 plugin to slug fields and find records by slug.
 - [Tools:Slugged](https://github.com/dereuromark/cakephp-tools) - Containing Slugged behavior to auto-generate URL-compatible slugs from titles.
 


### PR DESCRIPTION
A SEO plugin for cakePHP 3 to manage seo tags with ease. It comes with a Behavior, a Component, a View Cell and the default admin crud actions for each tables.

The behavior helps you to generate some default tags for each model. You can use simple text, pattern, callbacks.
The component inject tags in the view.
The view cell helps you to add or edit tags directly in the admin view of a record.