### PR TITLE
Replace Geshi with Markup plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,7 +193,7 @@ Additional lists you might find useful:
 *Plugins for working with markup.*
 
 - [CommonMark plugin](https://github.com/gourmet/common-mark) - Adds [CommonMark](http://commonmark.org/) Markdown parsing.
-- [Geshi plugin](https://github.com/markstory/cakephp_geshi) - For adding GeSHI syntax highlighting.
+- [Markup plugin](https://github.com/dereuromark/cakephp-markup) - Allows to use PHP or JS based syntax highlighting.
 
 ## Migration
 *Plugins and resources around migration and upgrading.*


### PR DESCRIPTION
https://github.com/dereuromark/cakephp-markup

Geshi is not usable anymore, I got a dependency issue because the dependency is not reachable via packagist. So my sandbox was broken.

This Markup plugin does the same thing, instead of

    $this->Geshi->highlightString(text)

it is now

    $this->Highlighter->highlight($text)

Demo now works again: http://sandbox3.dereuromark.de/sandbox/examples/markup

If in the future geshi works again, we can easily write a GeshiHighlighter.