### PR TITLE
Added RelatedContent plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -244,6 +244,7 @@ Additional lists you might find useful:
 - [PersistRelatedData plugin](https://github.com/riesenia/persist-related-data) - Behavior for persisting selected fields of related models.
 - [RowLocker plugin](https://github.com/lorenzo/row-locker) - Exclusive locks for rows in your tables.
 - [Webservices ORM plugin](https://github.com/usemuffin/webservice) - An ORM like interface for webservices.
+- [RelatedContent plugin](https://github.com/aiphee/CakePHP3-related-content-plugin) - Behaviors and element for managing many to many related entities from different models. 
 
 ## PDF
 *Plugins and software for working with PDF files.*


### PR DESCRIPTION
I created this plugin for managing related content.
It probably needs someone to test it first, since i'm the only one using it. 

I'm also not sure how do i write tests for behavior.

Examples of usage:
- Article has "read more" for other article
-  News has "read more" for other news or pages
- Article has related galleries

Plugin has two parts, one part is caching, and the second uses the cache.

It is my first plugin for PHP framework ever, so i embrace constructive criticism.