### PR TITLE
Added syntaxera/cakephp-sparkpost-plugin to list

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,7 +138,7 @@ Additional lists you might find useful:
 
 - [EmailQueue plugin](https://github.com/lorenzo/cakephp-email-queue) - Email queue plugin with a preview and sender shell.
 - [Gourmet/Email plugin](https://github.com/gourmet/email) - Email helper, layout and more.
-- [SparkPost plugin](https://github.com/syntaxera/sparkpost) - Email transport plugin for sending email via the SparkPost API.
+- [SparkPost plugin](https://github.com/syntaxera/cakephp-sparkpost-plugin) - Email transport plugin for sending email via the SparkPost API.
 
 ## Environment
 *Plugins for enviroment.*

--- a/README.md
+++ b/README.md
@@ -138,6 +138,7 @@ Additional lists you might find useful:
 
 - [EmailQueue plugin](https://github.com/lorenzo/cakephp-email-queue) - Email queue plugin with a preview and sender shell.
 - [Gourmet/Email plugin](https://github.com/gourmet/email) - Email helper, layout and more.
+- [SparkPost plugin](https://github.com/syntaxera/sparkpost) - Email transport plugin for sending email via the SparkPost API.
 
 ## Environment
 *Plugins for enviroment.*


### PR DESCRIPTION
After the Great Mandrill Schism (http://blog.mailchimp.com/important-changes-to-mandrill) a lot of users (myself included) were on the hunt for a free alternative. I knew people who were considering shutting down their little tiny webapps because they couldn't afford Mandrill's monthly fee. Fortunately, we found SparkPost, which offers the same thing Mandrill did with a few more features.

I noticed that there wasn't a CakePHP plugin for SparkPost, so I made one. It is open-source, MIT-licensed, implemented in English, and free forever.