### PR TITLE
Add DataTables plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -222,6 +222,7 @@ Additional lists you might find useful:
 - [CakeAdmin plugin](https://github.com/cakemanager/cakephp-cakeadmin) - A non-stable user management plugin with a built-in admin area.
 - [CurrencyConverter plugin](https://github.com/AlessandroMinoccheri/cakephp-currency-converter) - A plugin to convert currency into another one.
 - [Dashboard plugin](https://github.com/gourmet/dashboard) - Build beautiful dashboards for your cakes.
+- [DataTables plugin](https://github.com/ypnos-web/cakephp-datatables) - Create dynamic tables with jQuery DataTables and server-side processing
 - [Hashid plugin](https://github.com/dereuromark/cakephp-hashid) - Allows to use hashids to not expose the database ids to the user.
 - [Setup:Maintenance](https://github.com/dereuromark/cakephp-setup/blob/master/docs/Maintenance/Maintenance.md) - Maintenance shell to go into maintenance mode for all requests with optional IP whitelisting.
 - [Shim plugin](https://github.com/dereuromark/cakephp-shim) - A plugin containing useful shims and improvements as basis for your application.


### PR DESCRIPTION
https://github.com/ypnos-web/cakephp-datatables

The plugin consists of a Component and a Helper to easily use jQuery DataTables in a CakePHP app.
The component provides a finder wrapper that processes AJAX requests by DataTables.
The Helper provides an easy method of setting up the table in a template.
