### PR TITLE
Add CakePHP Interval plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -229,6 +229,7 @@ Additional lists you might find useful:
 - [Dashboard plugin](https://github.com/gourmet/dashboard) - Build beautiful dashboards for your cakes.
 - [Flash plugin](https://github.com/dereuromark/cakephp-flash) - More powerful flash messages for your application.
 - [Hashid plugin](https://github.com/dereuromark/cakephp-hashid) - Allows to use hashids to not expose the database ids to the user.
+- [Interval plugin](https://github.com/LubosRemplik/CakePHP-Interval) - Converts seconds to human readable string (string to seconds), uses business hours (1 week = 5 days, 1 day = 8 hours).
 - [MysqlBackup plugin](https://github.com/mirko-pagliai/cakephp-mysql-backup) - A plugin to export, import and manage MySQL database backups.
 - [Setup:Maintenance](https://github.com/dereuromark/cakephp-setup/blob/master/docs/Maintenance/Maintenance.md) - Maintenance shell to go into maintenance mode for all requests with optional IP whitelisting.
 - [Shim plugin](https://github.com/dereuromark/cakephp-shim) - A plugin containing useful shims and improvements as basis for your application.


### PR DESCRIPTION
Converts seconds to human readable string (string to seconds), uses business hours (1 week = 5 days, 1 day = 8 hours). See readme for more info.

Maybe `Interval` name is too abstract, let me know if you have better idea for name.

https://github.com/LubosRemplik/CakePHP-Interval