### PR TITLE
Adding Middleware Section

### DIFF
--- a/README.md
+++ b/README.md
@@ -215,11 +215,6 @@ Additional lists you might find useful:
 - [Gourmet/CommonMark plugin](https://github.com/gourmet/common-mark) - Adds [CommonMark](http://commonmark.org/) Markdown parsing.
 - [Markup plugin](https://github.com/dereuromark/cakephp-markup) - Allows to use PHP or JS based syntax highlighting.
 
-## Middleware
-*Plugins for Middleware*
-
-- [CakeMiddlewares](https://github.com/chrisShick/CakeMiddlewares) - A collection of Cakephp Middlewares. Requires CakePHP version 3.4+.
-
 ## Migration
 *Plugins and resources around migration and upgrading.*
 
@@ -234,6 +229,7 @@ Additional lists you might find useful:
 
 - [Ajax plugin](https://github.com/dereuromark/cakephp-ajax) - A plugin to ease handling AJAX requests.
 - [CakeAdmin plugin](https://github.com/cakemanager/cakephp-cakeadmin) - A non-stable user management plugin with a built-in admin area.
+- [CakeMiddlewares](https://github.com/chrisShick/CakeMiddlewares) - A collection of Cakephp Middlewares. Requires CakePHP version 3.4+.
 - [CurrencyConverter plugin](https://github.com/AlessandroMinoccheri/cakephp-currency-converter) - A plugin to convert currency into another one.
 - [Dashboard plugin](https://github.com/gourmet/dashboard) - Build beautiful dashboards for your cakes.
 - [Flash plugin](https://github.com/dereuromark/cakephp-flash) - More powerful flash messages for your application.

--- a/README.md
+++ b/README.md
@@ -215,6 +215,11 @@ Additional lists you might find useful:
 - [Gourmet/CommonMark plugin](https://github.com/gourmet/common-mark) - Adds [CommonMark](http://commonmark.org/) Markdown parsing.
 - [Markup plugin](https://github.com/dereuromark/cakephp-markup) - Allows to use PHP or JS based syntax highlighting.
 
+## Middleware
+*Plugins for Middleware*
+
+- [CakeMiddlewares](https://github.com/chrisShick/CakeMiddlewares) - A collection of Cakephp Middlewares. Requires CakePHP version 3.4+.
+
 ## Migration
 *Plugins and resources around migration and upgrading.*
 


### PR DESCRIPTION
Now that CakePHP is supporting Middleware, I feel that a middleware section is needed. I have also submitted my new [CakeMiddlewares](https://github.com/chrisShick/CakeMiddlewares) repo to start it off. 