### PR TITLE
Replace gourmet/knp-menu with icings/menu.

### DIFF
--- a/README.md
+++ b/README.md
@@ -251,7 +251,7 @@ Additional lists you might find useful:
 ## Navigation
 *Tools for building navigation structures.*
 
-- [KnpMenu plugin](https://github.com/gourmet/knp-menu) - A menu plugin based on the [Knp Menu Library](https://github.com/KnpLabs/KnpMenu).
+- [Icings/Menu plugin](https://github.com/icings/menu) - A [KnpMenu](https://github.com/KnpLabs/KnpMenu) seasoned menu plugin for CakePHP.
 
 ## NoSQL
 *Plugins for working with "NoSQL" backends.*


### PR DESCRIPTION
[**`gourmet/knp-menu`**](https://github.com/gourmet/knp-menu) doesn't seem to be maintained anymore, just like Gourmet in general.

Given the current state, I'd like to propose replacing `gourmet/knp-menu` with [**`icings/menu`**](https://github.com/icings/menu), which is based on KnpMenu too, and ships with a string template renderer, and URL as well as route based matching.

I've used it for internal projects for quite some time now, but had to make some larger changes for the public release, so it's currently in beta. Not sure what the rules regarding stability are, but I thought throwing the idea in the room before the first stable won't hurt.

ping @phillaf