### PR TITLE
Add cakephp-actions-class

### DIFF
--- a/README.md
+++ b/README.md
@@ -229,6 +229,7 @@ Additional lists you might find useful:
 ## Miscellaneous
 *Misc plugins and libraries.*
 
+- [ActionsClass plugin](https://github.com/HavokInspiration/cakephp-actions-class) - Gives you the ability to manage your Controllers actions as single classes
 - [Ajax plugin](https://github.com/dereuromark/cakephp-ajax) - A plugin to ease handling AJAX requests.
 - [CakeAdmin plugin](https://github.com/cakemanager/cakephp-cakeadmin) - A non-stable user management plugin with a built-in admin area.
 - [CakeMiddlewares](https://github.com/chrisShick/CakeMiddlewares) - A collection of Cakephp Middlewares.

--- a/README.md
+++ b/README.md
@@ -229,7 +229,7 @@ Additional lists you might find useful:
 ## Miscellaneous
 *Misc plugins and libraries.*
 
-- [ActionsClass plugin](https://github.com/HavokInspiration/cakephp-actions-class) - Gives you the ability to manage your Controllers actions as single classes
+- [ActionsClass plugin](https://github.com/HavokInspiration/cakephp-actions-class) - Gives you the ability to manage your Controller actions as single classes.
 - [Ajax plugin](https://github.com/dereuromark/cakephp-ajax) - A plugin to ease handling AJAX requests.
 - [CakeAdmin plugin](https://github.com/cakemanager/cakephp-cakeadmin) - A non-stable user management plugin with a built-in admin area.
 - [CakeMiddlewares](https://github.com/chrisShick/CakeMiddlewares) - A collection of Cakephp Middlewares.


### PR DESCRIPTION
I created a plugin that gives the ability to manage controllers actions as single classes. 
`Actions` classes have the same API as controllers (component loading, etc.) and can be tested using Integration testing. (they are in fact `Cake\Controller\Controller` subclasses).

Plugin can be found here : https://github.com/HavokInspiration/cakephp-actions-class
It works on CakePHP 3.4.X and I also tested it against CakePHP 3.5.0.