### PR TITLE
Add maintained and improved Whoops package.

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,9 +127,9 @@ Additional lists you might find useful:
 - [DebugKit plugin](https://github.com/cakephp/debug_kit) - The de-facto standard for debugging.
 - [ErrorEmail plugin](https://github.com/ebrigham1/cakephp-error-email) - A plugin to email exception/error information to your dev team.
 - [Execution order](https://github.com/dereuromark/executionorder) - A demo app to display the execution order of files, methods and callbacks.
-- [Gourmet/Whoops plugin](https://github.com/gourmet/whoops) - PHP error for cool kids with [filp/whoops](https://github.com/filp/whoops).
 - [Psa/FixtureCheck plugin](https://github.com/World-Architects/cakephp-fixture-check) - A plugin to help detect mismatches in live DB and fixtures in order to make fixture based tests more reliable and deployments safer.
 - [Setup plugin](https://github.com/dereuromark/cakephp-setup) - A lightweight setup plugin containing debugging and maintenance tools.
+- [Whoops plugin](https://github.com/dereuromark/cakephp-whoops) - PHP errors and exceptions for cool kids with [filp/whoops](https://github.com/filp/whoops).
 
 ## Dependency Injection
 *Plugins that implement the dependency injection design pattern.*


### PR DESCRIPTION
https://github.com/dereuromark/cakephp-whoops

Demo-Video: [Linux Mint + Firefox](https://streamable.com/s/h63t3/xweicf)

The original one seems not maintained anymore and has some unresolved issues. Also some improvements for IDE jumping have now been introduced.
