### PR TITLE
SweetAlertHelper plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -253,7 +253,7 @@ Additional lists you might find useful:
 - [Utils plugin](https://github.com/cakemanager/cakephp-utils) - Containing useful components (Authorizer, Menu) and behaviors (WhoDidIt, Uploadable, Metas, Stateable).
 - [Wrench plugin](https://github.com/HavokInspiration/wrench) - Maintenance Mode plugin. Easily extensible and customizable.
 - [Yaml plugin](https://github.com/guemidiborhane/Cake-Yaml) - For using YAML config files instead of PHP arrays.
-- [sweet-alert-cakephp-3](https://github.com/falco442/sweet-alert-cakephp-3) - To use `HtmlHelper::link` and `FormHelper::postLink` with confirmation dialog done with [Sweet Alert 2](https://sweetalert2.github.io/)
+- [SweetAlertHelper plugin](https://github.com/falco442/sweet-alert-cakephp-3) - To use `HtmlHelper::link` and `FormHelper::postLink` with confirmation dialog done with [Sweet Alert 2](https://sweetalert2.github.io/)
 
 ## Navigation
 *Tools for building navigation structures.*

--- a/README.md
+++ b/README.md
@@ -253,6 +253,7 @@ Additional lists you might find useful:
 - [Utils plugin](https://github.com/cakemanager/cakephp-utils) - Containing useful components (Authorizer, Menu) and behaviors (WhoDidIt, Uploadable, Metas, Stateable).
 - [Wrench plugin](https://github.com/HavokInspiration/wrench) - Maintenance Mode plugin. Easily extensible and customizable.
 - [Yaml plugin](https://github.com/guemidiborhane/Cake-Yaml) - For using YAML config files instead of PHP arrays.
+- [sweet-alert-cakephp-3](https://github.com/falco442/sweet-alert-cakephp-3) - To use `HtmlHelper::link` and `FormHelper::postLink` with confirmation dialog done with [Sweet Alert 2](https://sweetalert2.github.io/)
 
 ## Navigation
 *Tools for building navigation structures.*


### PR DESCRIPTION
Added my plugin [sweet-alert-cakephp-3](https://github.com/falco442/sweet-alert-cakephp-3); it allows to use HtmlHelper::link and FormHelper::link with sweet alert 2, a beautiful alert system, alternative to javascript alert