### PR TITLE
Add calendar plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -240,6 +240,7 @@ Additional lists you might find useful:
 - [CakeAdmin plugin](https://github.com/cakemanager/cakephp-cakeadmin) - A non-stable user management plugin with a built-in admin area.
 - [CakeDC/Enum](https://github.com/CakeDC/enum) - A plugin to add enumeration list support to your app.
 - [CakeMiddlewares](https://github.com/chrisShick/CakeMiddlewares) - A collection of Cakephp Middlewares.
+- [Calendar plugin](https://github.com/dereuromark/cakephp-calendar) - For generating basic calendars. Includes IcalView for ICS calendar file generation.
 - [Comments plugin](https://github.com/Kareylo/CakePHP-Comments) - A fully customizable Comments plugin.
 - [CurrencyConverter plugin](https://github.com/AlessandroMinoccheri/cakephp-currency-converter) - A plugin to convert currency into another one.
 - [Dashboard plugin](https://github.com/gourmet/dashboard) - Build beautiful dashboards for your cakes.


### PR DESCRIPTION
Adds https://github.com/dereuromark/cakephp-calendar

See 
- https://sandbox.dereuromark.de/sandbox/calendar for calendar example
- https://github.com/dereuromark/cakephp-calendar/tree/master/docs#icalendar-files-icalics for ics generating