### PR TITLE
Remove false statement about NewRelic plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ Additional lists you might find useful:
 ## APM
 *Plugins for Application Performance Monitoring.*
 
-- [NewRelic plugin](https://github.com/jippi/cakephp-newrelic/tree/cake3) - A complete plugin that enables full New Relic integration for a CakePHP application, including CLI naming, exceptions sending, custom timings, etc. It does not depend on New Relic agent.
+- [NewRelic plugin](https://github.com/jippi/cakephp-newrelic/tree/cake3) - A complete plugin that enables full New Relic integration for a CakePHP application, including CLI naming, exceptions sending, custom timings, etc.
 
 - [Brunitto/NewRelic plugin](https://github.com/brunitto/cakephp-new-relic) - A simple plugin that enables just name transaction and browser timing for a CakePHP 3 application using the New Relic PHP agent.
 


### PR DESCRIPTION
I believe the NewRelic plugin does depend on the newrelic agent very much: https://github.com/jippi/cakephp-newrelic/blob/cake3/src/Lib/NewRelic.php