### PR TITLE
Add Lampager plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -292,6 +292,7 @@ Additional lists you might find useful:
 - :strawberry: [CakeDecimal plugin](https://github.com/dereuromark/cakephp-decimal) - A value object approach on handling decimals.
 - :strawberry: [Duplicatable plugin](https://github.com/riesenia/cakephp-duplicatable) - Behavior for duplicating entities including related data.
 - [Fetchable plugin](https://github.com/riesenia/cakephp-fetchable) - Behavior for fetching entities from cache / memory.
+- :strawberry: [Lampager/Lampager plugin](https://github.com/lampager/lampager-cakephp) - Rapid pagination without using OFFSET.
 - [JeremyHarris/LazyLoad plugin](https://github.com/jeremyharris/cakephp-lazyload) - An association lazy loader for entities.
 - [Lqdt/OrmJson plugin](https://github.com/liqueurdetoile/cakephp-orm-json) - Behavior and Trait for selecting, finding, getting and setting properties and values inside JSON type fields through CakePHP ORM.
 - [Money plugin](https://github.com/gourmet/money) - Money data type for CakePHP entities using [sebastianbergmann/money](https://github.com/sebastianbergmann/money).


### PR DESCRIPTION
Adds https://github.com/lampager/lampager-cakephp to the ORM section of the list. This plugin handles rapid pagination using the cursor, which means it lists the items of the next page referring to the last item of the previous page, in order to make pagination incredibly faster. For more information as to how this plugin is embedded to a CakePHP application, please refer to our README. Thanks.