### PR TITLE
Switch to github actions

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -1,0 +1,14 @@
+on: push
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - uses: docker://dkhamsing/awesome_bot:latest
+      with:
+        args: --allow-redirect --allow-dupe --request-delay 1 --white-list www.vagrantup.com README.md
+    - uses: actions/upload-artifact@v1
+      if: failure()
+      with:
+        name: ab-results
+        path: ab-results-README.md-filtered.json

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,0 @@
-sudo: false
-language: ruby
-rvm:
-  - 2.2
-before_script:
-  - gem install awesome_bot
-script:
-  - awesome_bot README.md --allow-redirect --allow-dupe --white-list www.vagrantup.com


### PR DESCRIPTION
Introduces a workflow for github actions, as a replacement to the existing travis one.

A delay (one second) has been configured between requests to avoid HTTP 429 errors from github. The downside is that the validation step will need approximately 7 minutes to be completed. Another option is to completely ignore HTTP 429 errors - which is much faster but may include false positives.

Also, all problematic issues are uploaded to artifacts, in JSON format. 

