### PR TITLE
Add official Content Management Tutorial

### DIFF
--- a/README.md
+++ b/README.md
@@ -510,6 +510,7 @@ Various resources, such as books, websites and articles, for improving your Cake
 *Must-do tutorials.*
 
 - [Official Blog tutorial](https://book.cakephp.org/3.0/en/tutorials-and-examples/blog/blog.html)
+- :strawberry: [Official Content Management Tutorial](https://book.cakephp.org/4/en/tutorials-and-examples/cms/installation.html)
 
 ## CakePHP Reading and Listening
 *Documentation and CakePHP-related reading and listening materials.*


### PR DESCRIPTION
Since 4.x is current stable version of CakePHP, we should direct readers to the current version's tutorial page.

I've kept blog tutorial because we still have support for CakePHP 3.x. IMO, we keep it here for now and once we end support for CakePHP 3.x, then we can remove it. Wondering what core members thinks?