### PR TITLE
Added baserCMS

### DIFF
--- a/README.md
+++ b/README.md
@@ -356,6 +356,7 @@ IDE specific compatibility information and tips can be found [here](https://gith
 
 ## CMS and applications built on CakePHP
 
+- [baserCMS](https://github.com/baserproject/basercms) - This is a website development framework with RESTful APIs. Installable as a plugin for CakePHP 4.x.
 - [Croogo](https://croogo.org) - CMS software (see 5.0 branch).
 
 ## Demo


### PR DESCRIPTION
I would like to add baserCMS, a CMS made in Japan.

It was recently ported from CakePHP2 to CakePHP4 and added headless CMS functionality.

It supports English and Japanese.