### PR TITLE
Add Icon to Denote Galley CakePHP 5 Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -347,7 +347,7 @@ Additional lists you might find useful:
 - [CakePHP Vagrant Setup](https://github.com/cpierce/cakephp-vagrant-setup) - Tool for spinning up multiple CakePHP 3.x Vanilla Dev Environments.
 - [Devilbox](https://devilbox.readthedocs.io/en/latest/) - A docker development environment for (CakePHP) apps to be auto-setup including a lot of tools.
 - [Docker](https://github.com/stefanvangastel/docker-cakephp) - CakePHP in a docker container environment.
-- [Galley](https://gitlab.com/amayer5125/galley) - A small Docker dev environment for CakePHP development which includes a simple command line utility.
+- 🍰 [Galley](https://gitlab.com/amayer5125/galley) - A small Docker dev environment for CakePHP development which includes a simple command line utility.
 - [NetBeans](https://github.com/junichi11/cakephp3-netbeans) -  This package provides support for CakePHP in NetBeans 8.1+.
 - [Oven](https://github.com/CakeDC/oven) - Setup your favorite framework with 1 file and 1 click.
 - [Puppet](https://puppetlabs.com/) - A server automation framework and application.


### PR DESCRIPTION
As of version 1.5.0 [Galley](https://gitlab.com/amayer5125/galley) works with CakePHP 5.x applications.