### PR TITLE
Add more 🍰

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,7 +179,7 @@ Additional lists you might find useful:
 *Plugins for I18n (Internationalization) and L10n (Localization).*
 
 - 🍰 [ADmad/I18n plugin](https://github.com/ADmad/cakephp-i18n) - A plugin with I18n related tools.
-- [Cake/Localized plugin](https://github.com/cakephp/localized) - Localized validation and ready-to-use translation PO files.
+- 🍰 [Cake/Localized plugin](https://github.com/cakephp/localized) - Localized validation and ready-to-use translation PO files.
 - [Translate plugin](https://github.com/dereuromark/cakephp-translate) - Manage translations of your static content the easy way via web backend, incl. import from POT files, auto-suggest and auto-translate via API.
 
 ## Imagery


### PR DESCRIPTION
Automatically detected CakePHP 5 compatibility: 
- Cake/Localized

How it works:
- Takes each plugin and checks released Packagist versions.
- If a compatible 5.0-beta and higher is found, it will add the icon.
