### PR TITLE
Add more 🍰

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ Additional lists you might find useful:
 - 🍰 [AuditStash plugin](https://github.com/lorenzo/audit-stash) - Flexible and rock solid audit log tracking.
 - 🍰 [DatabaseLog plugin](https://github.com/dereuromark/CakePHP-DatabaseLog) - Simple and stand-alone logging to database instead of files.
 - 🍰 [Muffin/Footprint plugin](https://github.com/UseMuffin/Footprint) - Plugin to allow passing currently logged in user to model layer.
-- [Version plugin](https://github.com/josegonzalez/cakephp-version) - A plugin that facilitates versioned database entities.
+- 🍰 [Version plugin](https://github.com/josegonzalez/cakephp-version) - A plugin that facilitates versioned database entities.
 
 ## Authentication and Authorization
 *Plugins and libraries for implementing authentication and authorization.*


### PR DESCRIPTION
Automatically detected CakePHP 5 compatibility: 
- Version

How it works:
- Takes each plugin and checks released Packagist versions.
- If a compatible 5.0-beta and higher is found, it will add the icon.
