### PR TITLE
Add more 🍰

### DIFF
--- a/README.md
+++ b/README.md
@@ -243,7 +243,7 @@ Additional lists you might find useful:
 - 🍰 [ADmad/Sequence plugin](https://github.com/ADmad/cakephp-sequence) - Behavior for maintaining ordered list of records.
 - 🍰 [CakeDecimal plugin](https://github.com/dereuromark/cakephp-decimal) - A value object approach on handling decimals.
 - 🍰 [Duplicatable plugin](https://github.com/riesenia/cakephp-duplicatable) - Behavior for duplicating entities including related data.
-- [Lampager/Cake plugin](https://github.com/lampager/lampager-cakephp) - Rapid pagination without using OFFSET.
+- 🍰 [Lampager/Cake plugin](https://github.com/lampager/lampager-cakephp) - Rapid pagination without using OFFSET.
 - 🍰 [Muffin/Orderly plugin](https://github.com/usemuffin/orderly) - Allows setting default order for your tables.
 - [Muffin/Sti plugin](https://github.com/UseMuffin/Sti) - Single Table Inheritance for CakePHP. 
 - 🍰 [Muffin/Trash plugin](https://github.com/usemuffin/trash) - Soft-delete behavior for CakePHP.


### PR DESCRIPTION
Automatically detected CakePHP 5 compatibility: 
- Lampager/Cake

How it works:
- Takes each plugin and checks released Packagist versions.
- If a compatible 5.0-beta and higher is found, it will add the icon.
