### PR TITLE
Add more 🍰

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,7 +129,7 @@ Additional lists you might find useful:
 ## Debugging
 *Plugins for debugging and local development.*
 
-- [AssociationsDebugger plugin](https://github.com/zunnu/associations-debugger) - A plugin that draws your model associations as diagram.
+- 🍰 [AssociationsDebugger plugin](https://github.com/zunnu/associations-debugger) - A plugin that draws your model associations as diagram.
 - 🍰 [CakephpWhoops plugin](https://github.com/dereuromark/cakephp-whoops) - PHP errors and exceptions for cool kids with [filp/whoops](https://github.com/filp/whoops).
 - 🍰 [DebugKit plugin](https://github.com/cakephp/debug_kit) - The de-facto standard for debugging.
 - [Execution order](https://github.com/dereuromark/executionorder) - A demo app to display the execution order of files, methods and callbacks.


### PR DESCRIPTION
Automatically detected CakePHP 5 compatibility: 
- AssociationsDebugger

How it works:
- Takes each plugin and checks released Packagist versions.
- If a compatible 5.0-beta and higher is found, it will add the icon.
