### PR TITLE
Add back ApiPagination and EncryptedType plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -273,6 +273,7 @@ Additional lists you might find useful:
 - 🍰 [CRUD plugin](https://github.com/FriendsOfCake/crud) - CakePHP Application development on steroids - rapid prototyping / scaffolding & production-ready code.
 - [Alt3/Swagger plugin](https://github.com/alt3/cakephp-swagger) - Swagger 2.0 documentation for your CakePHP APIs using swagger-php and swagger-ui.
 - 🍰 [CakeDC/Api plugin](https://github.com/CakeDC/cakephp-api) - All-in-one solution to provide a complete API. It includes versioning, renderers, CRUD, authentication, extensions (paginate, filter, HATEOAS), and much more.
+- [BryanCrowe/ApiPagination plugin](https://github.com/bcrowe/cakephp-api-pagination) - Injects configurable pagination information from CakePHP's Paginator into API data envelopes through serialized JsonView and XmlView responses.
 - 🍰 [FractalTransformerView plugin](https://github.com/andrej-griniuk/cakephp-fractal-transformer-view) - A plugin which allows using [Fractal transformers](https://fractal.thephpleague.com/transformers/) for your API output.
 - 🍰 [MixerApi](https://mixerapi.com) - Streamline development of modern RESTful APIs for your team's CakePHP project.
 - 🍰 [SwaggerBake plugin](https://github.com/cnizzardini/cakephp-swagger-bake) - This plugin automatically builds OpenAPI from your existing models and routes for display in Swagger and Redoc.
@@ -290,6 +291,7 @@ Additional lists you might find useful:
 
 - [Bruteforce](https://github.com/Ali1/cakephp-bruteforce/) - Simple way to add Brute Force Protection to your installation without involving database.
 - 🍰 [Captcha plugin](https://github.com/dereuromark/cakephp-captcha) - Simple, unobtrusive and extendable captcha solution providing by default an image based math captcha.
+- [BryanCrowe/EncryptedType plugin](https://github.com/bcrowe/cakephp-encrypted-type) - Simple solution that provides a encrypted data type that applies application-level encryption and decryption to values being stored and read columns for at rest encryption.  through encryption performed at the application level before the databse.
 - 🍰 [Expose plugin](https://github.com/dereuromark/cakephp-expose) - Expose entities through additional UUIDs instead of their AIID primary keys to obfuscate those IDs and data associated with these numerically ordered values.
 - 🍰 [Muffin/Obfuscate plugin](https://github.com/usemuffin/obfuscate) - Primary key obfuscation/shortening using UUIDs, HashIds, Optimus, Tiny and/or custom obfuscation strategies.
 - 🍰 [Muffin/Throttle plugin](https://github.com/usemuffin/throttle) - A plugin for rate limiting (API) requests.

--- a/README.md
+++ b/README.md
@@ -273,7 +273,7 @@ Additional lists you might find useful:
 - 🍰 [CRUD plugin](https://github.com/FriendsOfCake/crud) - CakePHP Application development on steroids - rapid prototyping / scaffolding & production-ready code.
 - [Alt3/Swagger plugin](https://github.com/alt3/cakephp-swagger) - Swagger 2.0 documentation for your CakePHP APIs using swagger-php and swagger-ui.
 - 🍰 [CakeDC/Api plugin](https://github.com/CakeDC/cakephp-api) - All-in-one solution to provide a complete API. It includes versioning, renderers, CRUD, authentication, extensions (paginate, filter, HATEOAS), and much more.
-- [BryanCrowe/ApiPagination plugin](https://github.com/bcrowe/cakephp-api-pagination) - Injects configurable pagination information from CakePHP's Paginator into API data envelopes through serialized JsonView and XmlView responses.
+- [BryanCrowe/ApiPagination plugin](https://github.com/bcrowe/cakephp-api-pagination) - Automatically adds fully configurable pagination metadata from CakePHP’s built-in pagination to JsonView or XmlView API responses by encapsulating payload data in an envelope.
 - 🍰 [FractalTransformerView plugin](https://github.com/andrej-griniuk/cakephp-fractal-transformer-view) - A plugin which allows using [Fractal transformers](https://fractal.thephpleague.com/transformers/) for your API output.
 - 🍰 [MixerApi](https://mixerapi.com) - Streamline development of modern RESTful APIs for your team's CakePHP project.
 - 🍰 [SwaggerBake plugin](https://github.com/cnizzardini/cakephp-swagger-bake) - This plugin automatically builds OpenAPI from your existing models and routes for display in Swagger and Redoc.
@@ -291,7 +291,7 @@ Additional lists you might find useful:
 
 - [Bruteforce](https://github.com/Ali1/cakephp-bruteforce/) - Simple way to add Brute Force Protection to your installation without involving database.
 - 🍰 [Captcha plugin](https://github.com/dereuromark/cakephp-captcha) - Simple, unobtrusive and extendable captcha solution providing by default an image based math captcha.
-- [BryanCrowe/EncryptedType plugin](https://github.com/bcrowe/cakephp-encrypted-type) - Simple solution that provides a encrypted data type that applies application-level encryption and decryption to values being stored and read columns for at rest encryption.  through encryption performed at the application level before the databse.
+- [BryanCrowe/EncryptedType plugin](https://github.com/bcrowe/cakephp-encrypted-type) - A straightforward solution that enables field-level (column) encryption within the application layer before data is stored or transmitted to the database, supporting regulatory compliance, zero-trust security, end-to-end encryption, and contextual awareness.
 - 🍰 [Expose plugin](https://github.com/dereuromark/cakephp-expose) - Expose entities through additional UUIDs instead of their AIID primary keys to obfuscate those IDs and data associated with these numerically ordered values.
 - 🍰 [Muffin/Obfuscate plugin](https://github.com/usemuffin/obfuscate) - Primary key obfuscation/shortening using UUIDs, HashIds, Optimus, Tiny and/or custom obfuscation strategies.
 - 🍰 [Muffin/Throttle plugin](https://github.com/usemuffin/throttle) - A plugin for rate limiting (API) requests.


### PR DESCRIPTION
They were removed in an initial clean up of non-compatibility with 4.x, but since then they've been updated to be compatible with 4.x for a while now. They'll both soon be getting updated for 5.x compatibility as well.