### PR TITLE
Add CakeVerification plugin to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,8 @@ Additional lists you might find useful:
 - [Authentication plugin](https://github.com/cakephp/authentication) - Official CakePHP authentication middleware plugin.
 - [Authorization plugin](https://github.com/cakephp/authorization) - Official CakePHP authorization stack.
 - [CakeDC/Users plugin](https://github.com/CakeDC/users) - Complete user management (admin panel, remember me, etc), Social login (FB, Twitter, LinkedIn, Google, Instagram), RBAC, API and more.
+- [CakeVerification plugin](https://github.com/salines/cakephp-verification) - Two-factor verification supporting email OTP, email magic link, SMS OTP, and TOTP (Google Authenticator).
+
 - [TinyAuth plugin](https://github.com/dereuromark/cakephp-tinyauth) - Authentication and role-based (single/multi) authorization as very light-weight approach.
 - [Tools:Passwordable](https://github.com/dereuromark/cakephp-tools) - Containing [Passwordable behavior](https://github.com/dereuromark/cakephp-tools/blob/master/docs/Behavior/Passwordable.md) for a DRY approach on password hashing.
 - [TwoFactorAuth plugin](https://github.com/andrej-griniuk/cakephp-two-factor-auth) - Allows two factor authentication using Google Authenticator or similar app to generate one-time codes. Based on [RobThree/TwoFactorAuth](https://github.com/RobThree/TwoFactorAuth) library.


### PR DESCRIPTION
Adds CakeVerification plugin to the Authentication and Authorization section.

- https://github.com/salines/cakephp-verification
- Packagist: salines/cakephp-verification
- MIT license
- CakePHP 5.3+, PHP 8.2+
- Supports email OTP, email magic link, SMS OTP, and TOTP (Google Authenticator)
- Composer installable, tested, CI included, documented

<!--
## Checklist

- [ ] CakePHP 5.x and PHP 8.1+ compatible
- [ ] Has tests, documentation, and LICENSE file
- [ ] Actively maintained
- [ ] One suggestion per PR

## Formatting

- [ ] Format: `[Plugin Name](URL) - Your description.`
- [ ] Description ends with a period
- [ ] Alphabetical order within category

Add a link to your repository in PR description below the next line.
-->
