### PR TITLE
Fix awesome-lint issues for sindresorhus/awesome compliance

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Awesome CakePHP [![Awesome](https://cdn.rawgit.com/sindresorhus/awesome/d7305f38d29fed78fa85652e3a63e154dd8e8829/media/badge.svg)](https://github.com/sindresorhus/awesome)
+# Awesome CakePHP [![Awesome](https://awesome.re/badge.svg)](https://awesome.re)
 A curated list of amazingly awesome **CakePHP 5.x** plugins, resources and shiny things.
 
 If you are looking for previous CakePHP resources please visit:
@@ -16,7 +16,7 @@ Additional lists you might find useful:
 > plugin subparts (instead of only the whole plugin/repo), more granular
 > grouping and the primary focus on task-specific functionality.
 
-## Table of Contents
+## Contents
 
 - [Plugins](#plugins)
 	- [AI Tools](#ai-tools)
@@ -54,7 +54,7 @@ Additional lists you might find useful:
 	- [Third Party APIs](#third-party-apis)
 - [Software](#software)
 	- [Development Environment](#development-environment)
-- [Web Applications](#web-applications)
+	- [Web Applications](#web-applications)
 	- [CMS and applications built on CakePHP](#cms-and-applications-built-on-cakephp)
 	- [Demo](#demo)
 - [Resources](#resources)
@@ -66,28 +66,27 @@ Additional lists you might find useful:
 	- [CakePHP Reading and Listening](#cakephp-reading-and-listening)
 	- [CakePHP Internals Reading](#cakephp-internals-reading)
 - [Conferences](#conferences)
-- [Contributing](#contributing)
 
-# Plugins
+## Plugins
 
-## AI Tools
+### AI Tools
 *Plugins and libraries for integrating artificial intelligence and machine learning tools.*
 
 - [Crustum/OpenRouter plugin](https://github.com/crustum/cakephp-open-router) - Integration with OpenRouter service for unified LLM access, supporting multiple AI models with chat completions, streaming, tool calling, and web search.
 - [Synapse plugin](https://github.com/josbeir/cakephp-synapse) - Expose your application functionality via MCP, with built-in tools and documentation search to help you discover and interact with your app's capabilities.
 
-## Architecture
+### Architecture
 
 - [Burzum/CakeServiceLayer plugin](https://github.com/burzum/cakephp-service-layer) - Service layer and domain/business model implementation.
 
-## Asset Management
+### Asset Management
 *Managing, compressing and minifying website assets.*
 
 - [AssetCompress plugin](https://github.com/markstory/asset_compress) - A complete asset manager for CakePHP.
 - [AssetMix plugin](https://github.com/ishanvyas22/asset-mix) - Provides integration with [Laravel Mix](https://laravel-mix.com) asset compilation.
 - [CakeVite plugin](https://github.com/josbeir/cakephp-vite) - A fully-featured [Vite](https://vite.dev/) plugin (spiritual successor of [brandcom/cakephp-vite](https://github.com/brandcom/cakephp-vite)).
 
-## Auditing / Logging
+### Auditing / Logging
 *Tracking changes and events in your app.*
 
 - [AuditStash plugin](https://github.com/dereuromark/cakephp-audit-stash) - Flexible and rock solid audit log tracking.
@@ -96,7 +95,7 @@ Additional lists you might find useful:
 - [Muffin/Footprint plugin](https://github.com/UseMuffin/Footprint) - Plugin to allow passing currently logged in user to model layer.
 - [Version plugin](https://github.com/josegonzalez/cakephp-version) - A plugin that facilitates versioned database entities.
 
-## Authentication and Authorization
+### Authentication and Authorization
 *Plugins and libraries for implementing authentication and authorization.*
 
 - [ADmad/SocialAuth plugin](https://github.com/ADmad/cakephp-social-auth) - A plugin which allows you to authenticate using social providers like Facebook/Google/Twitter etc. using [SocialConnect/auth](https://github.com/SocialConnect/auth) social sign on library.
@@ -110,13 +109,13 @@ Additional lists you might find useful:
 - [Tools:Passwordable](https://github.com/dereuromark/cakephp-tools) - Containing [Passwordable behavior](https://github.com/dereuromark/cakephp-tools/blob/master/docs/Behavior/Passwordable.md) for a DRY approach on password hashing.
 - [TwoFactorAuth plugin](https://github.com/andrej-griniuk/cakephp-two-factor-auth) - Allows two factor authentication using Google Authenticator or similar app to generate one-time codes. Based on [RobThree/TwoFactorAuth](https://github.com/RobThree/TwoFactorAuth) library.
 
-## Caching
+### Caching
 *Storing data for faster retrieval.*
 
 - [Cache plugin](https://github.com/dereuromark/cakephp-cache) - For caching views (HTML, CSV, JSON, XML, ...) as static cache files.
 - [CakeDC/CachedRouting plugin](https://github.com/CakeDC/cakephp-cached-routing) - Provides a cached version of the RoutingMiddleware to improve the load time of routes.
 
-## Code Analysis
+### Code Analysis
 *Analyzing, parsing and manipulation codebases.*
 
 - [cakedc/cakephp-phpstan](https://github.com/CakeDC/cakephp-phpstan) - A PHPStan extension to resolve CakePHP magic around getter return types for the static analyzer.
@@ -125,35 +124,35 @@ Additional lists you might find useful:
 - [lordsimal/cakephp-psalm](https://github.com/LordSimal/cakephp-psalm) - A Psalm extension to resolve CakePHP magic around getter return types for the static analyzer.
 - [TestHelper plugin](https://github.com/dereuromark/cakephp-test-helper) - Provides testing enhancements and TDD support as browser backend.
 
-## Console
+### Console
 *Command-line tools and improvements.*
 
 - [SignalHandler plugin](https://github.com/skie/SignalHandler) - Cross-platform signal handling for CakePHP console commands with zero external dependencies. Supports Linux (pcntl), Windows (native API).
 - [Scheduling plugin](https://github.com/skie/cakephp-scheduling) - The plugin provides task scheduling capabilities with sub-minute precision, allowing you to schedule tasks as frequently as every second, with single crontab entry point. It allows tasks monitoring.
 
-## Debugging
+### Debugging
 *Debugging and local development.*
 
 - [AssociationsDebugger plugin](https://github.com/zunnu/associations-debugger) - A plugin that draws your model associations as diagram.
 - [CakephpWhoops plugin](https://github.com/dereuromark/cakephp-whoops) - PHP errors and exceptions for cool kids with [filp/whoops](https://github.com/filp/whoops).
 - [DebugKit plugin](https://github.com/cakephp/debug_kit) - The de-facto standard for debugging.
 - [Execution order](https://github.com/dereuromark/executionorder) - A demo app to display the execution order of files, methods and callbacks.
-- [Sentry plugin](https://github.com/lordsimal/cakephp-sentry) A plugin to seamlessly integrate Sentry for errors and exceptions.
+- [Sentry plugin](https://github.com/lordsimal/cakephp-sentry) - A plugin to seamlessly integrate Sentry for errors and exceptions.
 - [Setup plugin](https://github.com/dereuromark/cakephp-setup) - A lightweight setup plugin containing healthcheck(s), debugging and maintenance tools.
 
-## Email
+### Email
 *Transports and tools for email handling.*
 
 - [Queue plugin](https://github.com/dereuromark/cakephp-queue) - A dependency-free queue-based mail solution using Mailer/Email class, allowing re-queue on (network) failure.
 - [SendGrid plugin](https://github.com/sprintcube/cakephp-sendgrid) - Email transport plugin for sending email via SendGrid API.
 
-## File Manipulation
+### File Manipulation
 *Upload, storage, and file handling.*
 
 - [FileStorage plugin](https://github.com/dereuromark/cakephp-file-storage) - Flexible file storage and upload plugin.
 - [Josegonzalez/Upload plugin](https://github.com/FriendsOfCake/cakephp-upload) - A customisable plugin that uses [Flysystem](https://flysystem.thephpleague.com/) to write to multiple backends (Dropbox, FTP, S3, Local, etc.).
 
-## Filtering and Validation
+### Filtering and Validation
 *Data sanitization and validation rules.*
 
 - see Cake/Localized plugin below.
@@ -161,25 +160,25 @@ Additional lists you might find useful:
 - [RuleFlow plugin](https://github.com/skie/rule-flow) - A plugin that seamlessly transforms server-side validation rules into client-side JSON Logic validation, providing automatic form validation without requiring separate client-side validation code.
 
 
-## Geolocation
+### Geolocation
 *Geocoding addresses and working with latitudes and longitudes.*
 
 - [Geo plugin](https://github.com/dereuromark/cakephp-geo) - Containing [Geocoder behavior](https://www.dereuromark.de/2012/06/12/geocoding-with-cakephp/) and [GoogleMaps helper](https://www.dereuromark.de/2010/12/21/googlemapsv3-cakephp-helper/).
 
-## I18n
+### I18n
 *I18n (Internationalization) and L10n (Localization).*
 
 - [ADmad/I18n plugin](https://github.com/ADmad/cakephp-i18n) - A plugin with I18n related tools.
 - [Cake/Localized plugin](https://github.com/cakephp/localized) - Localized validation and ready-to-use translation PO files.
 - [Translate plugin](https://github.com/dereuromark/cakephp-translate) - Translate your translations in the backend with ease.
 
-## Imagery
+### Imagery
 *Image processing and manipulation libraries.*
 
 - [ADmad/Glide plugin](https://github.com/ADmad/cakephp-glide) - A plugin for using [Glide](https://glide.thephpleague.com/) image manipulation library.
 - [QrCodePlugin](https://github.com/dereuromark/cakephp-qrcode/) - Easily render SVG/PNG QR Codes for your app.
 
-## Libs
+### Libs
 *Useful libraries or tools that don't fit in any of the other categories.*
 
 - [Chronos](https://github.com/cakephp/chronos) - A simple standalone DateTime API extension (successor of Carbon).
@@ -188,12 +187,12 @@ Additional lists you might find useful:
 - [Graphviz](https://github.com/alexandresalome/graphviz) - A Graphviz library.
 - [Rocketeer](https://github.com/rocketeers/rocketeer) - PHP task runner and deployment package.
 
-## Markup
+### Markup
 *Syntax highlighting and markup processing.*
 
 - [Markup plugin](https://github.com/dereuromark/cakephp-markup) - Allows to use PHP or JS based syntax highlighting.
 
-## Migration
+### Migration
 *Plugins and resources around migration and upgrading.*
 
 - [Migrations plugin](https://github.com/cakephp/migrations) - (DB) Migration plugin.
@@ -201,7 +200,7 @@ Additional lists you might find useful:
 - [Upgrade app (extended)](https://github.com/dereuromark/upgrade) - An extended upgrade app for 3.x=>4.x and some 5.x snippets.
 - [Upgrade/Migration Guide](https://book.cakephp.org/5/en/appendices.html) - Official migration guide.
 
-## Miscellaneous
+### Miscellaneous
 *Misc plugins and libraries.*
 
 - [Ajax plugin](https://github.com/dereuromark/cakephp-ajax) - A plugin to ease handling AJAX requests.
@@ -210,7 +209,7 @@ Additional lists you might find useful:
 - [CakeDto plugin](https://github.com/dereuromark/cakephp-dto) - Quickly generate useful data transfer objects for your app (mutable/immutable), replacing messy arrays and leveraging your IDE through typehinting and autocomplete.
 - [CakeHtmx plugin](https://github.com/zunnu/cake-htmx) - CakePHP integration for [htmx](https://htmx.org/).
 - [Calendar plugin](https://github.com/dereuromark/cakephp-calendar) - For generating basic calendars. Includes IcalView for ICS calendar file generation.
-- [DatabaseBackup plugin](https://github.com/mirko-pagliai/cakephp-database-backup) - A plugin to to export, import and manage database backups. Currently, the plugin supports MySql, Postgres and Sqlite databases.
+- [DatabaseBackup plugin](https://github.com/mirko-pagliai/cakephp-database-backup) - A plugin to export, import and manage database backups. Currently, the plugin supports MySQL, PostgreSQL and SQLite databases.
 - [Feedback plugin](https://github.com/dereuromark/cakephp-feedback) - Allow visitors to send quick and easy feedback incl. a screenshot via sidebar form.
 - [Flash plugin](https://github.com/dereuromark/cakephp-flash) - More powerful flash messages for your application.
 - [Inertia plugin](https://github.com/CakeDC/cakephp-inertia) - Plugin for connecting a Vue 3 app and use an API interface using a middleware.
@@ -219,19 +218,19 @@ Additional lists you might find useful:
 - [Shim plugin](https://github.com/dereuromark/cakephp-shim) - A plugin containing useful shims and improvements as basis for your application.
 - [Tools plugin](https://github.com/dereuromark/cakephp-tools) - Containing lots of useful helpers, behaviors, components, commands, helpers, libs and more.
 
-## Navigation
+### Navigation
 *Building navigation structures.*
 
 - [Icings/Menu plugin](https://github.com/icings/menu) - A [KnpMenu](https://github.com/KnpLabs/KnpMenu) seasoned menu plugin for CakePHP.
 
-## Notifications and Real-time Communication
+### Notifications and Real-time Communication
 *Working with notification software.*
 
 - [Crustum/Broadcasting plugin](https://github.com/crustum/broadcasting) - The Broadcasting plugin provides real-time event broadcasting for CakePHP applications using WebSocket connections compatible with the Pusher protocol or Redis pub/sub.
 - [Crustum/Notification plugin](https://github.com/crustum/notification) - The Notification plugin provides support for sending notifications across a variety of delivery channels.
 - [Mercure plugin](https://github.com/josbeir/cakephp-mercure) - Push real-time updates to clients using the Mercure protocol.
 
-## ORM / Database / Datamapping
+### ORM / Database / Datamapping
 *Plugins that implement object-relational mapping or data-mapping techniques.*
 
 - [ADmad/Sequence plugin](https://github.com/ADmad/cakephp-sequence) - Behavior for maintaining ordered list of records.
@@ -244,12 +243,12 @@ Additional lists you might find useful:
 - [Itosho/EasyQuery plugin](https://github.com/itosho/easy-query) - Behavior for easily generating some complicated queries like (bulk) insert/upsert etc.
 - [Icings/Partitionable plugin](https://github.com/icings/partitionable) - Partitionable associations allowing for basic limiting per group.
 
-## PDF
+### PDF
 *Plugins and software for working with PDF files.*
 
 - [CakePdf plugin](https://github.com/FriendsOfCake/CakePdf) - A plugin around PDF generation.
 
-## Queue
+### Queue
 *Working with event and task queues.*
 
 - [Queue plugin](https://github.com/cakephp/queue) - CakePHP core queue system for the [php-queue](https://php-enqueue.github.io) queue library.
@@ -259,7 +258,7 @@ Additional lists you might find useful:
 - [Queue plugin](https://github.com/dereuromark/cakephp-queue) - A minimal and dependency-free queue solution.
 - [QueueScheduler plugin](https://github.com/dereuromark/cakephp-queue-scheduler) - A dependency-free crontab-like scheduler as DB driven solution and addon to Queue (dereuromark) plugin.
 
-## REST and API
+### REST and API
 *Plugins and web tools for developing REST-ful APIs.*
 
 - [CRUD plugin](https://github.com/FriendsOfCake/crud) - CakePHP Application development on steroids - rapid prototyping / scaffolding & production-ready code.
@@ -268,16 +267,16 @@ Additional lists you might find useful:
 - [MixerApi](https://mixerapi.com) - Streamline development of modern RESTful APIs for your team's CakePHP project.
 - [SwaggerBake plugin](https://github.com/cnizzardini/cakephp-swagger-bake) - This plugin automatically builds OpenAPI from your existing models and routes for display in Swagger and Redoc.
 
-## Search
+### Search
 *Plugins and software for indexing and performing search queries on data.*
 
-- [Cake/ElasticSearch plugin](https://github.com/cakephp/elastic-search) - Alternative ORM using [Elasticsearch](https://www.elastic.co/) as its backend.
+- [Cake/Elasticsearch plugin](https://github.com/cakephp/elastic-search) - Alternative ORM using [Elasticsearch](https://www.elastic.co/) as its backend.
 - [CakeDC/SearchFilter plugin](https://github.com/CakeDC/search-filter) - Powerful and flexible solution for implementing advanced search functionality. Provides a robust set of tools for creating dynamic, user-friendly search interfaces with minimal effort.
 - [PlumSearch plugin](https://github.com/skie/plum_search) - Implements custom, flexible and extendable search strategies. Implements PRG pattern.
 - [Search plugin](https://github.com/FriendsOfCake/search) - Provides easy searching/filtering for paginated views using PRG pattern.
 - [Tags plugin](https://github.com/dereuromark/cakephp-tags) - For tagging and finding tagged records.
 
-## Security
+### Security
 *Plugins and information around security, preventing vulnerabilities and protection against XSS and alike.*
 
 - [Captcha plugin](https://github.com/dereuromark/cakephp-captcha) - Simple, unobtrusive and extendable captcha solution providing by default an image based math captcha.
@@ -286,26 +285,26 @@ Additional lists you might find useful:
 - [Muffin/Throttle plugin](https://github.com/usemuffin/throttle) - A plugin for rate limiting (API) requests.
 - [Recaptcha plugin](https://github.com/ctlabvn/Recaptcha) - Simple, lightweight Google Recaptcha v2.
 
-## SEO
+### SEO
 *Search Engine Optimization.*
 
 - [Muffin/Slug plugin](https://github.com/UseMuffin/Slug) - A plugin for generating slugs and finding records by slug. Uses a pluggable architecture which allows using your own slug generator class.
 - [Tools:Slugged](https://github.com/dereuromark/cakephp-tools) - Containing Slugged behavior to auto-generate URL-compatible slugs from titles.
 
-## Skeleton
+### Skeleton
 *Plugins and repositories around app skeletons.*
 
 - [App template](https://github.com/cakephp/app) - An empty CakePHP project for use with composer.
 - [BS flavored App template](https://github.com/dereuromark/cakephp-app) - An empty CakePHP project with BS5 and FontAwesome out of the box.
 
-## Social
+### Social
 *Plugins around social features.*
 
 - [Comments plugin](https://github.com/dereuromark/cakephp-comments) - Allows users to comment records, supporting different formats.
 - [Favorites plugin](https://github.com/dereuromark/cakephp-favorites) - Allows users to star/like/favor records.
 - [Ratings plugin](https://github.com/dereuromark/cakephp-ratings) - Allows users to rate records and displays ratings.
 
-## Templating
+### Templating
 *Template engines and view generation.*
 
 - [Bake plugin](https://github.com/cakephp/bake) - Provides code generation functionality.
@@ -320,29 +319,30 @@ Additional lists you might find useful:
 - [TwigView plugin](https://github.com/cakephp/twig-view) - A plugin to use the Twig Templating Language for views.
 - [XlsView plugin](https://github.com/impronta48/cakephp-xlsview) - A view class to easily generate XLS using PHPSpreadsheet.
 
-## Testing
+### Testing
 *Plugins/Tools for testing codebases and generating test data.*
 
 - [CakePHP CodeSniffer rules](https://github.com/cakephp/cakephp-codesniffer) - The official CakePHP CS rules.
 - [CakephpFixtureFactories plugin](https://github.com/dereuromark/cakephp-fixture-factories) - Create your fixtures dynamically on a test basis, accelerate the writing and maintenance of your tests.
-- [FriendsOfCake/Fixturize plugin](https://github.com/FriendsOfCake/fixturize) - More efficient inserting fixtures when running test suites by decreasing amount of inserts (mysql only).
+- [FriendsOfCake/Fixturize plugin](https://github.com/FriendsOfCake/fixturize) - More efficient inserting fixtures when running test suites by decreasing amount of inserts (MySQL only).
 
-## Third Party APIs
+### Third Party APIs
 *Accessing third party APIs.*
 
 
-# Software
+## Software
+
 *Software for creating a development environment.*
 
-## Development Environment
+### Development Environment
 *Software and tools for creating a sandboxed development environment.*
 
-- [CakePHP Docker](https://github.com/cnizzardini/cakephp-docker) - A cakephp/app template for docker.
+- [CakePHP Docker](https://github.com/cnizzardini/cakephp-docker) - A cakephp/app template for Docker.
 - [CakePHP Vagrant Setup](https://github.com/cpierce/cakephp-vagrant-setup) - Tool for spinning up multiple CakePHP vanilla dev environments using Vagrant.
 - [CakePHP Docker Setup](https://github.com/cpierce/cakephp-docker-setup) - Tool for spinning up multiple CakePHP vanilla dev environments using Docker.
 - [DDEV](https://ddev.readthedocs.io/en/stable/) - Docker based local env.
-- [Devilbox](https://devilbox.readthedocs.io/en/latest/) - A docker development environment for (CakePHP) apps to be auto-setup including a lot of tools.
-- [Docker](https://github.com/stefanvangastel/docker-cakephp) - CakePHP in a docker container environment.
+- [Devilbox](https://devilbox.readthedocs.io/en/latest/) - A Docker development environment for (CakePHP) apps to be auto-setup including a lot of tools.
+- [Docker](https://github.com/stefanvangastel/docker-cakephp) - CakePHP in a Docker container environment.
 - [Galley](https://gitlab.com/amayer5125/galley) - A small Docker dev environment for CakePHP development which includes a simple command line utility.
 - [NetBeans](https://github.com/junichi11/cakephp3-netbeans) - This package provides support for CakePHP in NetBeans 8.1+.
 - [Oven](https://github.com/CakeDC/oven) - Setup your favorite framework with 1 file and 1 click.
@@ -351,34 +351,36 @@ Additional lists you might find useful:
 
 IDE specific compatibility information and tips can be found [here](https://github.com/dereuromark/cakephp-ide-helper/wiki#ide-support-and-tips).
 
-## Web Applications
+### Web Applications
 
-## CMS and applications built on CakePHP
+### CMS and applications built on CakePHP
 
 - [baserCMS](https://github.com/baserproject/basercms) - This is a website development framework with RESTful APIs. Installable as a plugin for CakePHP.
 
-## Demo
+### Demo
+
 *Web-based (demo) applications and tools.*
 
 - [BlogMVC](https://github.com/Kareylo/BlogMVC-CakePHP3) - A simple Blog example with CakePHP based on [BlogMVC Project](https://github.com/Grafikart/BlogMVC).
-- [Bookmarkr](https://github.com/lorenzo/cakephp3-bookmarkr) A bookmarking application built with the CRUD plugin.
-- [Fluentd + Grafana Loki demo application](https://github.com/ishanvyas22/cakephp-loki-demo) - A demo application to send CakePHP docker container logs to [Grafana Loki](https://grafana.com/logs/) via [Fluentd](https://www.fluentd.org/).
+- [Bookmarkr](https://github.com/lorenzo/cakephp3-bookmarkr) - A bookmarking application built with the CRUD plugin.
+- [Fluentd + Grafana Loki demo application](https://github.com/ishanvyas22/cakephp-loki-demo) - A demo application to send CakePHP Docker container logs to [Grafana Loki](https://grafana.com/logs/) via [Fluentd](https://www.fluentd.org/).
 - [RealWorld](https://github.com/gothinkster/cakephp-realworld-example-app) - Example CakePHP codebase containing real world examples (CRUD, auth, advanced patterns and more) that adheres to the [RealWorld](https://github.com/gothinkster/realworld-example-apps) spec and API.
 - [Sandbox](https://sandbox.dereuromark.de) - A sandbox CakePHP application with lots of demos and plugin showcasings.
-- [Query Examples](https://github.com/lorenzo/cakephp3-examples) Advanced query building examples.
+- [Query Examples](https://github.com/lorenzo/cakephp3-examples) - Advanced query building examples.
 - [Xeta](https://github.com/XetaIO/Xeta) - A resource to help people starting with CakePHP.
-- [Vue.js Demo App](https://github.com/ishanvyas22/cakephpvue-spa) - A CakePHP + VueJS single page application skeleton.
+- [Vue.js Demo App](https://github.com/ishanvyas22/cakephpvue-spa) - A CakePHP + Vue.js single page application skeleton.
 
-# Resources
+## Resources
+
 Various resources, such as books, websites and articles, for improving your CakePHP development skills and knowledge.
 
-## Help
+### Help
 *Where to get help.*
 
 - [Official CakePHP Forum](https://discourse.cakephp.org/) - This is for generic questions and alike.
 - [stackoverflow.com/questions/tagged/cakephp](https://stackoverflow.com/questions/tagged/cakephp) - This is for specific questions, ideally along with some example code.
 
-## CakePHP Websites
+### CakePHP Websites
 *Useful and current CakePHP-related websites and blogs.*
 
 - [CakeDC](https://www.cakedc.com/articles) - Articles around CakePHP.
@@ -386,41 +388,41 @@ Various resources, such as books, websites and articles, for improving your Cake
 - [josediazgonzalez.com](https://josediazgonzalez.com/) - A mainly CakePHP related core dev blog.
 - [mark-story.com](https://mark-story.com) - CakePHP lead dev blog.
 
-## CakePHP Books and Articles
+### CakePHP Books and Articles
 *Fantastic CakePHP-related (e)books and other reading material.*
 
-## CakePHP Videos
+### CakePHP Videos
 *Fantastic CakePHP-related videos.*
 
 - [CakePHP](https://www.youtube.com/user/CakePHP) - Channel about CakePHP videos.
 
 
-## CakePHP Tutorials
+### CakePHP Tutorials
 *Must-do tutorials.*
 
 - [Official Content Management Tutorial](https://book.cakephp.org/5/en/tutorials-and-examples/cms/installation.html)
 
-## CakePHP Reading and Listening
+### CakePHP Reading and Listening
 *Documentation and CakePHP-related reading and listening materials.*
 
 - [CakePHP Cookbook(!)](https://book.cakephp.org/) - The official CakePHP documentation.
 
-## CakePHP Internals Reading
+### CakePHP Internals Reading
 *Reading materials related to the CakePHP internals and decisions.*
 
 - [Top 10 (and more) core contributors](https://github.com/cakephp/cakephp/graphs/contributors) - Give 'em a hand.
 
-# Conferences
+## Conferences
 
-## Official
+### Official
 *International conference.*
 
 - [cakefest.org](https://cakefest.org/) - Annual CakePHP Conference.
 
-## MeetUps
+### MeetUps
 *Regional meet-ups.*
 
 - [CakePHP-DE](https://www.meetup.com/CakePHP-DE) - MeetUps in Germany.
 
-## Credits
+## Footnotes
 awesome-cakephp has been created by [dereuromark](https://github.com/dereuromark) and is currently maintained by him and the FriendsOfCake group. Thank you to all [contributors](https://github.com/FriendsOfCake/awesome-cakephp/graphs/contributors), too.


### PR DESCRIPTION
## Summary

Fixes issues flagged by `awesome-lint` to prepare for potential listing in [sindresorhus/awesome](https://github.com/sindresorhus/awesome).

Changes:
- Update badge to awesome.re format
- Rename "Table of Contents" to "Contents"
- Remove "Contributing" from ToC (per awesome guidelines)
- Fix heading hierarchy (only one `#` heading allowed, others become `##`/`###`)
- Fix ToC structure for nested sections under Software
- Add missing dash separators in list items
- Fix spelling: MySQL, PostgreSQL, SQLite, Elasticsearch, Docker, Vue.js
- Rename "Credits" to "Footnotes"
- Fix typo "to to" → "to" in DatabaseBackup description

### Remaining awesome-lint notices

The following are expected/intentional:
- **Duplicate links**: The Tools and Queue plugins are linked multiple times because this list explicitly supports "plugin subparts" (different features from the same repo)