### PR TITLE
Add TailwindUi plugin to Templating section

### DIFF
--- a/README.md
+++ b/README.md
@@ -316,6 +316,7 @@ Additional lists you might find useful:
 - [Feed plugin](https://github.com/dereuromark/cakephp-feed) - Containing an RssView class to easily generate (complex) RSS feeds.
 - [LatteView plugin](https://github.com/josbeir/cakephp-latte-view) - A plugin providing Latte template engine integration.
 - [Meta plugin](https://github.com/dereuromark/cakephp-meta) - Makes handling meta tags and SEO-relevant HTML markup DRY and easy.
+- [TailwindUi plugin](https://github.com/dereuromark/cakephp-tailwind-ui) - Tailwind CSS / DaisyUI (or KTUI/Metronic) integration for form, pagination, flash, and breadcrumb helpers.
 - [TemplaterDefaults plugin](https://github.com/josbeir/cakephp-templater-defaults) - Allows the use of default HTML attributes within CakePHP's string template system.
 - [Templating](https://github.com/dereuromark/cakephp-templating) - HTML snippets as value objects, (Font) icons, and templating topics.
 - [Tools:Tree](https://github.com/dereuromark/cakephp-tools) - Tree helper to work with Core Tree behavior and handle tree structure output.


### PR DESCRIPTION
## Summary

- Adds [dereuromark/cakephp-tailwind-ui](https://github.com/dereuromark/cakephp-tailwind-ui) to the Templating section, placed alphabetically between Meta and TemplaterDefaults.
- The plugin is the Tailwind CSS / DaisyUI equivalent of friendsofcake/bootstrap-ui — it provides drop-in replacement FormHelper, PaginatorHelper, FlashHelper, BreadcrumbsHelper, and HtmlHelper that emit Tailwind/DaisyUI markup.
- Ships with a configurable ClassMap system supporting DaisyUI (default), KTUI/Metronic, and custom presets, plus a bake theme.

Release: https://github.com/dereuromark/cakephp-tailwind-ui/releases/tag/0.1.0