### PR TITLE
Add Workflow plugin to Miscellaneous section

### DIFF
--- a/README.md
+++ b/README.md
@@ -221,6 +221,7 @@ Additional lists you might find useful:
 - [Setup:Maintenance](https://github.com/dereuromark/cakephp-setup/blob/master/docs/Maintenance/Maintenance.md) - Maintenance shell to go into maintenance mode for all requests with optional IP whitelisting.
 - [Shim plugin](https://github.com/dereuromark/cakephp-shim) - A plugin containing useful shims and improvements as basis for your application.
 - [Tools plugin](https://github.com/dereuromark/cakephp-tools) - Containing lots of useful helpers, behaviors, components, commands, helpers, libs and more.
+- [Workflow plugin](https://github.com/dereuromark/cakephp-workflow) - Batteries-included state machine plugin with PHP 8 attributes, YAML config, audit trails, and visual admin dashboard.
 
 ### Navigation
 *Building navigation structures.*


### PR DESCRIPTION
Adds [dereuromark/cakephp-workflow](https://github.com/dereuromark/cakephp-workflow) to the **Miscellaneous** section.

A batteries-included finite state machine plugin for CakePHP, featuring:

- PHP 8 Attribute-based workflow definitions
- YAML configuration support
- Built-in audit trails for transitions
- Visual admin dashboard for inspecting workflows / states / history
- MIT licensed, PHP 8.1+, Composer-installable, `cakephp-plugin` type

Inserted alphabetically at the end of the Miscellaneous list (after `Tools plugin`).