### PR TITLE
Add cakephp-menu to Navigation plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -226,8 +226,8 @@ Additional lists you might find useful:
 ### Navigation
 *Building navigation structures.*
 
-- [dereuromark/cakephp-menu plugin](https://github.com/dereuromark/cakephp-menu) - Composable menu builder and renderer for nested navigation, active-state matching, and breadcrumbs.
 - [Icings/Menu plugin](https://github.com/icings/menu) - A [KnpMenu](https://github.com/KnpLabs/KnpMenu) seasoned menu plugin for CakePHP.
+- [Menu plugin](https://github.com/dereuromark/cakephp-menu) - Composable menu builder and renderer for nested navigation, active-state matching, and breadcrumbs - and zero dependencies.
 
 ### Notifications and Real-time Communication
 *Working with notification software.*

--- a/README.md
+++ b/README.md
@@ -226,6 +226,7 @@ Additional lists you might find useful:
 ### Navigation
 *Building navigation structures.*
 
+- [dereuromark/cakephp-menu plugin](https://github.com/dereuromark/cakephp-menu) - Composable menu builder and renderer for nested navigation, active-state matching, and breadcrumbs.
 - [Icings/Menu plugin](https://github.com/icings/menu) - A [KnpMenu](https://github.com/KnpLabs/KnpMenu) seasoned menu plugin for CakePHP.
 
 ### Notifications and Real-time Communication


### PR DESCRIPTION
Adds `dereuromark/cakephp-menu` to the `Navigation` section.

This is a Cake native alternative, with zero dependencies. Focus on simple and effective Cake menus.

Suggested entry:

- [dereuromark/cakephp-menu plugin](https://github.com/dereuromark/cakephp-menu) - Composable menu builder and renderer for nested navigation, active-state matching, and breadcrumbs.
