### PR TITLE
Add CakePHP Claude Skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,6 +212,7 @@ Additional lists you might find useful:
 - [CakeDC/Enum plugin](https://github.com/CakeDC/enum) - A plugin to add enumeration list support to your app.
 - [CakeDto plugin](https://github.com/dereuromark/cakephp-dto) - Quickly generate useful data transfer objects for your app (mutable/immutable), replacing messy arrays and leveraging your IDE through typehinting and autocomplete.
 - [CakeHtmx plugin](https://github.com/zunnu/cake-htmx) - CakePHP integration for [htmx](https://htmx.org/).
+- [CakePHP Claude Skill](https://github.com/cpierce/cakephp-claude-skill) - Claude Code skill for CakePHP development covering conventions, PHPStan compliance, migrations, and upgrade guidance.
 - [Calendar plugin](https://github.com/dereuromark/cakephp-calendar) - For generating basic calendars. Includes IcalView for ICS calendar file generation.
 - [DatabaseBackup plugin](https://github.com/mirko-pagliai/cakephp-database-backup) - A plugin to export, import and manage database backups. Currently, the plugin supports MySQL, PostgreSQL and SQLite databases.
 - [Feedback plugin](https://github.com/dereuromark/cakephp-feedback) - Allow visitors to send quick and easy feedback incl. a screenshot via sidebar form.


### PR DESCRIPTION
<!--
## Checklist

- [x] CakePHP 5.x and PHP 8.1+ compatible
- [x] Has tests, documentation, and LICENSE file
- [x] Actively maintained
- [x] One suggestion per PR

## Formatting

- [x] Format: `[Plugin Name](URL) - Your description.`
- [x] Description ends with a period
- [x] Alphabetical order within category

Add a link to your repository in PR description below the next line.
-->

https://github.com/cpierce/cakephp-claude-skill

Adds the CakePHP Claude Skill to the Miscellaneous section: a Claude Code skill that guides AI-assisted CakePHP development — framework conventions, PHPStan compliance, migrations, testing, and 4.x to 5.x upgrade guidance. MIT licensed with documentation in the repo.

Note: this is a development tool rather than a Composer-installable plugin, so the plugin-specific checklist items (tests, PHP compatibility) apply in spirit — happy to move it to a different section if you'd prefer.
