### PR TITLE
Add CakeSymfonyMailer plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,6 +146,7 @@ Additional lists you might find useful:
 ### Email
 *Transports and tools for email handling.*
 
+- [CakeSymfonyMailer plugin](https://github.com/josbeir/cakephp-symfony-mailer) - Use Symfony Mailer as a CakePHP mail transport.
 - [Queue plugin](https://github.com/dereuromark/cakephp-queue) - A dependency-free queue-based mail solution using Mailer/Email class, allowing re-queue on (network) failure.
 - [SendGrid plugin](https://github.com/sprintcube/cakephp-sendgrid) - Email transport plugin for sending email via SendGrid API.
 


### PR DESCRIPTION
Adds CakeSymfonyMailer, a CakePHP 5 mail transport that hands CakePHP-rendered MIME messages to Symfony Mailer for delivery. This keeps CakePHP mailer APIs and message composition while enabling Symfony Mailer transports, including SMTP and provider/API transports.

Project page: https://github.com/josbeir/cakephp-symfony-mailer