### PR TITLE
Add Heartbeat plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,7 +140,7 @@ Additional lists you might find useful:
 - [CakephpWhoops plugin](https://github.com/dereuromark/cakephp-whoops) - PHP errors and exceptions for cool kids with [filp/whoops](https://github.com/filp/whoops).
 - [DebugKit plugin](https://github.com/cakephp/debug_kit) - The de-facto standard for debugging.
 - [Execution order](https://github.com/dereuromark/executionorder) - A demo app to display the execution order of files, methods and callbacks.
-- [Heartbeat plugin](https://github.com/orca-services/cakephp-heartbeat) - A plugin providing an application heartbeat status page with configurable sensors.
+- [OrcaServices/Heartbeat plugin](https://github.com/orca-services/cakephp-heartbeat) - A plugin providing an application heartbeat status page with configurable sensors.
 - [Sentry plugin](https://github.com/lordsimal/cakephp-sentry) - A plugin to seamlessly integrate Sentry for errors and exceptions.
 - [Setup plugin](https://github.com/dereuromark/cakephp-setup) - A lightweight setup plugin containing healthcheck(s), debugging and maintenance tools.
 

--- a/README.md
+++ b/README.md
@@ -140,6 +140,7 @@ Additional lists you might find useful:
 - [CakephpWhoops plugin](https://github.com/dereuromark/cakephp-whoops) - PHP errors and exceptions for cool kids with [filp/whoops](https://github.com/filp/whoops).
 - [DebugKit plugin](https://github.com/cakephp/debug_kit) - The de-facto standard for debugging.
 - [Execution order](https://github.com/dereuromark/executionorder) - A demo app to display the execution order of files, methods and callbacks.
+- [Heartbeat plugin](https://github.com/orca-services/cakephp-heartbeat) - A plugin providing an application heartbeat status page with configurable sensors.
 - [Sentry plugin](https://github.com/lordsimal/cakephp-sentry) - A plugin to seamlessly integrate Sentry for errors and exceptions.
 - [Setup plugin](https://github.com/dereuromark/cakephp-setup) - A lightweight setup plugin containing healthcheck(s), debugging and maintenance tools.
 


### PR DESCRIPTION
<!--
## Checklist

- [ ] CakePHP 5.x and PHP 8.1+ compatible
- [ ] Has tests, documentation, and LICENSE file
- [ ] Actively maintained
- [ ] One suggestion per PR

## Formatting

- [ ] Format: `[Plugin Name](URL) - Your description.`
- [ ] Description ends with a period
- [ ] Alphabetical order within category

Add a link to your repository in PR description below the next line.
-->
Adds Heartbeat, a CakePHP plugin providing an application heartbeat status page with configurable sensors.

https://github.com/orca-services/cakephp-heartbeat
