### PR TITLE
Add AppVersion plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,6 +209,7 @@ Additional lists you might find useful:
 *Misc plugins and libraries.*
 
 - [Ajax plugin](https://github.com/dereuromark/cakephp-ajax) - A plugin to ease handling AJAX requests.
+- [AppVersion plugin](https://github.com/orca-services/cakephp-app-version) - A plugin for adding a configurable app version as an HTTP header.
 - [AttributeRegistry plugin](https://github.com/josbeir/cakephp-attribute-registry) - A powerful CakePHP plugin for discovering, caching, and querying PHP 8 attributes across your application and plugins.
 - [CakeDC/Enum plugin](https://github.com/CakeDC/enum) - A plugin to add enumeration list support to your app.
 - [CakeDto plugin](https://github.com/dereuromark/cakephp-dto) - Quickly generate useful data transfer objects for your app (mutable/immutable), replacing messy arrays and leveraging your IDE through typehinting and autocomplete.


### PR DESCRIPTION
<!--
## Checklist

- [ ] CakePHP 5.x and PHP 8.1+ compatible
- [ ] Has tests, documentation, and LICENSE file
- [ ] Actively maintained
- [ ] One suggestion per PR

## Formatting

- [ ] Format: `[Plugin Name](URL) - Your description.`
- [ ] Description ends with a period
- [ ] Alphabetical order within category

Add a link to your repository in PR description below the next line.
-->
Adds AppVersion, a plugin for adding a configurable app version as an HTTP header.

https://github.com/orca-services/cakephp-app-version
