### PR TITLE
Fix broken link for Setup:Maintenance plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -219,7 +219,7 @@ Additional lists you might find useful:
 - [Flash plugin](https://github.com/dereuromark/cakephp-flash) - More powerful flash messages for your application.
 - [Inertia plugin](https://github.com/CakeDC/cakephp-inertia) - Plugin for connecting a Vue 3 app and use an API interface using a middleware.
 - [OPCache Preloader](https://github.com/cnizzardini/cakephp-preloader) - An OPCache Preloader for CakePHP applications. 
-- [Setup:Maintenance](https://github.com/dereuromark/cakephp-setup/blob/master/docs/Maintenance/Maintenance.md) - Maintenance shell to go into maintenance mode for all requests with optional IP whitelisting.
+- [Setup:Maintenance](https://github.com/dereuromark/cakephp-setup/blob/master/docs/maintenance/index.md) - Maintenance shell to go into maintenance mode for all requests with optional IP whitelisting.
 - [Shim plugin](https://github.com/dereuromark/cakephp-shim) - A plugin containing useful shims and improvements as basis for your application.
 - [Tools plugin](https://github.com/dereuromark/cakephp-tools) - Containing lots of useful helpers, behaviors, components, commands, helpers, libs and more.
 - [Workflow plugin](https://github.com/dereuromark/cakephp-workflow) - Batteries-included state machine plugin with PHP 8 attributes, YAML config, audit trails, and visual admin dashboard.


### PR DESCRIPTION
You have a few errors in the build pipeline.

I was able to replace one URL that was no longer up to date.

However, the Stack Overflow and YouTube links seem to be working.  
I don't know why the pipeline is throwing an error here.

```
Issues :-(
> Links 
  1. [L223] 404 https://github.com/dereuromark/cakephp-setup/blob/master/docs/Maintenance/Maintenance.md  
  2. [L392] 403 https://stackoverflow.com/questions/tagged/cakephp  
  3. [L408]  https://www.youtube.com/user/CakePHP Connection reset by peer - SSL_connect 
```

